### PR TITLE
Atualizei o roteamento na tela de ranking

### DIFF
--- a/flutter_application_1/lib/src/features/ranking/ranking_screen.dart
+++ b/flutter_application_1/lib/src/features/ranking/ranking_screen.dart
@@ -32,7 +32,7 @@ class RankingScreenState extends State<RankingScreen> {
       appBar: CustomNavigationBar(
         title: 'Ranking',
         onBackButtonPressed: () {
-          Navigator.pop(context, '/home');
+            Navigator.pushNamed(context, '/home');
         },
         onProfileButtonPressed: () {
           // Botao tela perfil


### PR DESCRIPTION
Descobri que o Navigator.pop funciona para voltar uma tela atrás e o Navigator.pushNamed trás a tela selecionada no lugar. Por mais que o Navigator.pop parece gastar menos recurso, o outro evita erro de voltar pra tela errada