### PR TITLE
📝 Card-007 Visualização de grupos e tela intermediaria feita

### DIFF
--- a/flutter_application_1/lib/src/features/intermediary/entrar_grupo.dart
+++ b/flutter_application_1/lib/src/features/intermediary/entrar_grupo.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class JoinExistingGroupScreen extends StatefulWidget {
+  const JoinExistingGroupScreen({Key? key}) : super(key: key);
+
+  @override
+  State<JoinExistingGroupScreen> createState() =>
+      _JoinExistingGroupScreenState();
+}
+
+class _JoinExistingGroupScreenState extends State<JoinExistingGroupScreen> {
+  List<Map<String, dynamic>> availableGroups = [];
+  bool isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadGroups();
+  }
+
+  Future<void> _loadGroups() async {
+    final user = Supabase.instance.client.auth.currentUser;
+    if (user == null) {
+      setState(() {
+        isLoading = false;
+      });
+      return;
+    }
+
+    // 1. Busca os grupos em que o usuário já está inserido
+    final userGroupsResponse = await Supabase.instance.client
+        .from('grupo_usuarios')
+        .select('grupo_id')
+        .eq('usuario_id', user.id);
+
+    // Converte a resposta em uma lista de IDs de grupo
+    final List<int> userGroupIds = (userGroupsResponse as List)
+        .map((item) => item['grupo_id'] as int)
+        .toList();
+
+    // 2. Busca todos os grupos da tabela 'grupo'
+    final allGroupsResponse =
+        await Supabase.instance.client.from('grupo').select();
+    final List<Map<String, dynamic>> allGroups = (allGroupsResponse as List)
+        .map((item) => item as Map<String, dynamic>)
+        .toList();
+
+    // 3. Filtra para mostrar apenas os grupos que o usuário NÃO está inserido
+    final List<Map<String, dynamic>> groupsToJoin = allGroups.where((grupo) {
+      return !userGroupIds.contains(grupo['id']);
+    }).toList();
+
+    setState(() {
+      availableGroups = groupsToJoin;
+      isLoading = false;
+    });
+  }
+
+  Future<void> _joinGroup(int grupoId) async {
+    final user = Supabase.instance.client.auth.currentUser;
+    if (user == null) return;
+
+    // Insere o registro na tabela 'grupo_usuarios' com sequencia 0 e data atual
+    await Supabase.instance.client.from('grupo_usuarios').insert({
+      'grupo_id': grupoId,
+      'usuario_id': user.id,
+      'sequencia': 0,
+      'ultimo_dia_ativo': DateTime.now().toIso8601String(),
+    });
+
+    // Retorna para a tela anterior indicando que houve alteração
+    Navigator.pop(context, true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Entrar em um grupo existente'),
+      ),
+      body: isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : availableGroups.isEmpty
+              ? const Center(
+                  child: Text(
+                    'Não há grupos disponíveis para entrar.',
+                    style: TextStyle(fontSize: 16),
+                  ),
+                )
+              : ListView.builder(
+                  itemCount: availableGroups.length,
+                  itemBuilder: (context, index) {
+                    final grupo = availableGroups[index];
+                    return ListTile(
+                      title: Text(grupo['nomeGroup'] ?? 'Sem nome'),
+                      subtitle:
+                          Text(grupo['descricaoGroup'] ?? 'Sem descrição'),
+                      onTap: () => _joinGroup(grupo['id']),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/flutter_application_1/lib/src/features/intermediary/tela_intermediaria.dart
+++ b/flutter_application_1/lib/src/features/intermediary/tela_intermediaria.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import '../registers/register_class.dart';
+import '../intermediary/entrar_grupo.dart'; // vamos criar essa tela a seguir
+import '../../common/constants/app_colors.dart'; // Certifique-se de que AppColors está acessível
+
+class ChooseGroupOptionScreen extends StatelessWidget {
+  const ChooseGroupOptionScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          'Escolha uma opção',
+          style: TextStyle(fontFamily: 'Montserrat'),
+        ),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // Imagem acima dos botões
+              Image.asset(
+                'assets/images/RatoBrancoFundoAzul.png',
+                height: 150, // Ajuste o tamanho da imagem conforme necessário
+                fit: BoxFit.contain, // Ajusta o conteúdo da imagem
+              ),
+              const SizedBox(height: 30), // Espaço entre a imagem e os botões
+
+              // Botão para criar novo grupo
+              SizedBox(
+                width: 200,
+                height: 40,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.laranja,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(30),
+                      side: BorderSide(
+                        color: AppColors.azulEscuro,
+                        width: 2,
+                      ),
+                    ),
+                  ),
+                  onPressed: () async {
+                    // Navega para a tela de criação
+                    final novoGrupo = await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => RegisterClassScreen()),
+                    );
+
+                    // Se voltou com algo não-nulo, significa que criou um grupo
+                    // e precisamos recarregar a Home
+                    Navigator.pop(context, novoGrupo != null);
+                  },
+                  child: const Text(
+                    'Criar novo grupo',
+                    style: TextStyle(
+                      color: AppColors.branco,
+                      fontFamily: 'Montserrat',
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              // Botão para entrar em um grupo existente
+              SizedBox(
+                width: 200,
+                height: 50,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.laranja,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(30),
+                      side: BorderSide(
+                        color: AppColors.azulEscuro,
+                        width: 2,
+                      ),
+                    ),
+                  ),
+                  onPressed: () async {
+                    final entrouEmGrupo = await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) =>
+                              const JoinExistingGroupScreen()),
+                    );
+
+                    // Se voltou com true, significa que entrou em algum grupo
+                    Navigator.pop(context, entrouEmGrupo == true);
+                  },
+                  child: const Text(
+                    'Entrar em um grupo existente',
+                    style: TextStyle(
+                      color: AppColors.branco,
+                      fontFamily: 'Montserrat',
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# 🚀 O que foi feito?
   Agora apenas grupos que o usuário participa estão sendo mostrados na tela de home.
   Adicionado uma tela intermediária que da opção do usuário criar uma nova tela ou entrar em um grupo existente.

Este pull request implementa as seguintes mudanças no projeto:
## ✨ Novos Arquivos Criados
       flutter_application_1/lib/src/features/intermediary/tela_intermediaria.dart
           Agora quando é clicado no botão flutuante essa tela é chamada para o usuário escolher se vai entrar num grupo ou criar um novo. 
           
       flutter_application_1/lib/src/features/intermediary/entrar_grupo.dart
           Tela responsável por listar todos os grupos disponíveis para o usuário entrar.

## 🔄 Arquivos Modificados

    flutter_application_1/lib/src/features/home/home_screen.dart
        Agora a tela de home exibe apenas os grupos que o usuário está inserido.
 
