### PR TITLE
 📝 Card-007 Tela de pomodoro aprimorada e salvamento no banco de dados ajustado

### DIFF
--- a/flutter_application_1/lib/app.dart
+++ b/flutter_application_1/lib/app.dart
@@ -52,6 +52,7 @@ class App extends StatelessWidget {
           final args = settings.arguments as Map<String, dynamic>;
           return MaterialPageRoute(
             builder: (context) => PomodoroScreen(
+              grupo: args['grupo'],
               usuarioId: args['usuarioId'],
               grupoId: args['grupoId'],
             ),

--- a/flutter_application_1/lib/src/features/activities/activities_screen.dart
+++ b/flutter_application_1/lib/src/features/activities/activities_screen.dart
@@ -121,6 +121,7 @@ void _onItemTapped(int index) {
           context,
           '/pomodoro',
           arguments: {
+            'grupo': grupo,
             'usuarioId': usuarioId,
             'grupoId': grupo['id'], // Pegando o ID do grupo atual
           },

--- a/flutter_application_1/lib/src/features/map/map_screen.dart
+++ b/flutter_application_1/lib/src/features/map/map_screen.dart
@@ -38,6 +38,7 @@ void _onItemTapped(int index) {
           context,
           '/pomodoro',
           arguments: {
+            'grupo': grupo,
             'usuarioId': usuarioId,
             'grupoId': grupo['id'], // Pegando o ID do grupo atual
           },

--- a/flutter_application_1/lib/src/features/ranking/ranking_screen.dart
+++ b/flutter_application_1/lib/src/features/ranking/ranking_screen.dart
@@ -36,6 +36,7 @@ void _onItemTapped(int index) {
           context,
           '/pomodoro',
           arguments: {
+            'grupo': grupo,
             'usuarioId': usuarioId,
             'grupoId': grupo['id'], // Pegando o ID do grupo atual
           },


### PR DESCRIPTION
# 🚀 O que foi feito?
   Agora apenas grupos que o usuário participa estão sendo mostrados na tela de home.
   Adicionado uma tela intermediária que da opção do usuário criar uma nova tela ou entrar em um grupo existente.

Este pull request implementa as seguintes mudanças no projeto:

## ✨ Novos Arquivos Criados
       flutter_application_1/lib/src/features/pomodoro/tela_pomodoro.dart
       Agora as sessões de pomodoro do usuário são mostradas e salvas no banco de dados corretamente
           
 
