### PR TITLE
Atualizei as setas de direcionamento do início do app

### DIFF
--- a/flutter_application_1/lib/src/features/cadastro/cadastro_screen.dart
+++ b/flutter_application_1/lib/src/features/cadastro/cadastro_screen.dart
@@ -60,19 +60,17 @@ class _CadastroPageState extends State<CadastroPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.branco,
-        appBar: AppBar(
+      appBar: AppBar(
         title: Text(''),
         centerTitle: true,
         backgroundColor: AppColors.branco,
-        actions: [
-          IconButton(
+        leading: IconButton(
             icon: Icon(Icons.arrow_back),
             color: AppColors.azulEscuro,
             onPressed: () {
               Navigator.pushReplacementNamed(context, '/onboarding');
             },
           ),
-        ]
       ),
       body: SingleChildScrollView(
         child: Padding(

--- a/flutter_application_1/lib/src/features/login/forgot_password.dart
+++ b/flutter_application_1/lib/src/features/login/forgot_password.dart
@@ -224,15 +224,14 @@ Future<void> _updatePassword() async {
         title: Text(''),
         centerTitle: true,
         backgroundColor: AppColors.branco,
-        actions: [
-          IconButton(
-            icon: Icon(Icons.arrow_back),
-            color: AppColors.azulEscuro,
-            onPressed: () {
-              Navigator.pop(context);
-            },
-          ),
-        ],
+        automaticallyImplyLeading: false, 
+        leading: IconButton(  
+          icon: Icon(Icons.arrow_back),
+          color: AppColors.azulEscuro,
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
       ),
       body: SingleChildScrollView(
         child: Padding(

--- a/flutter_application_1/lib/src/features/login/login_screen.dart
+++ b/flutter_application_1/lib/src/features/login/login_screen.dart
@@ -42,19 +42,17 @@ class _LoginPageState extends State<LoginPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.branco,
-        appBar: AppBar(
+      appBar: AppBar(
         title: Text(''),
         centerTitle: true,
         backgroundColor: AppColors.branco,
-        actions: [
-          IconButton(
+        leading: IconButton(
             icon: Icon(Icons.arrow_back),
             color: AppColors.azulEscuro,
             onPressed: () {
               Navigator.pushReplacementNamed(context, '/onboarding');
             },
           ),
-        ]
       ),
       body: SingleChildScrollView(
         child: Padding(


### PR DESCRIPTION
- > Nas telas de login e cadastro, as setas de retorno estavam no canto superior direito ao invés do canto superior esquerdo;

- > Na tela de esqueci a senha, haviam duas setas de retorno;

------

- > Todas as setas foram padronizadas para o canto superior esquerdo, conforme o restante do app.